### PR TITLE
Add direct music API tests without Starlette dependency

### DIFF
--- a/server/tests/integration/test_music_api_integration.py
+++ b/server/tests/integration/test_music_api_integration.py
@@ -1,0 +1,97 @@
+"""
+Integration tests for the music API.
+"""
+import os
+import pytest
+import requests
+
+# Mark all tests in this module as integration tests, music tests, and slow tests
+pytestmark = [pytest.mark.integration, pytest.mark.music, pytest.mark.slow]
+from src.api.music_api import get_music_api_provider, MusicResponseOutput
+
+# Test data
+TEST_PROMPT = "Create a short, gentle melody with piano"
+TEST_TIMEOUT = 120.0  # Longer timeout for integration tests
+
+def is_server_reachable(url):
+    """Check if a server is reachable."""
+    try:
+        response = requests.get(f"{url}/health", timeout=5)
+        return response.status_code == 200
+    except requests.RequestException:
+        return False
+
+@pytest.mark.parametrize("model_key", ["noise", "audioldm2", "musicgen-small"])
+def test_music_api_provider_creation(model_key):
+    """Test that we can create a music API provider for each model."""
+    # Get the provider for the specified model
+    provider = get_music_api_provider(model_key)
+    
+    # Verify the provider has the correct configuration
+    assert provider.model_name == model_key
+    assert "base_url" in provider.config
+    assert "check_interval" in provider.config
+    assert "max_wait_time" in provider.config
+    
+    # Log the configuration
+    print(f"Model: {model_key}, Base URL: {provider.config['base_url']}")
+
+@pytest.mark.parametrize("model_key", ["noise", "audioldm2", "musicgen-small"])
+def test_music_generation_if_server_available(model_key):
+    """
+    Test music generation if the server is available.
+    This test will be skipped if the server is not reachable.
+    """
+    # Get the provider for the specified model
+    provider = get_music_api_provider(model_key)
+    base_url = provider.config["base_url"]
+    
+    # Skip if the server is not reachable
+    if not is_server_reachable(base_url):
+        pytest.skip(f"Server for {model_key} is not reachable at {base_url}")
+    
+    # Configure the provider with a longer timeout for integration testing
+    provider = get_music_api_provider(
+        model_key=model_key,
+        max_wait_time=TEST_TIMEOUT
+    )
+    
+    # Generate music
+    print(f"Generating music with {model_key} model...")
+    response = provider.generate_music(prompt=TEST_PROMPT, seed=42)
+    
+    # Check the response
+    assert isinstance(response, MusicResponseOutput)
+    
+    if response.error:
+        print(f"Error generating music with {model_key}: {response.error}")
+        # Don't fail the test if there's an error, as the server might be temporarily unavailable
+    else:
+        assert response.audio_data is not None
+        assert len(response.audio_data) > 0
+        print(f"Successfully generated music with {model_key}, audio size: {len(response.audio_data)} bytes")
+        
+        # Save the audio file for manual inspection (optional)
+        os.makedirs("test_output", exist_ok=True)
+        with open(f"test_output/{model_key}_test_output.mp3", "wb") as f:
+            f.write(response.audio_data)
+        print(f"Saved audio to test_output/{model_key}_test_output.mp3")
+
+def test_music_api_error_handling():
+    """Test that the music API handles errors correctly."""
+    # Create a provider with an invalid base URL
+    provider = get_music_api_provider(
+        model_key="test-model",
+        base_url="http://invalid-url-that-does-not-exist.example.com",
+        check_interval=0.1,
+        max_wait_time=1.0
+    )
+    
+    # Generate music (should fail)
+    response = provider.generate_music(prompt=TEST_PROMPT)
+    
+    # Verify the response contains an error
+    assert isinstance(response, MusicResponseOutput)
+    assert response.audio_data is None
+    assert response.error is not None
+    assert "API request failed" in response.error

--- a/server/tests/unit/test_music_api_direct.py
+++ b/server/tests/unit/test_music_api_direct.py
@@ -1,0 +1,241 @@
+"""
+Direct unit tests for the music API without using Starlette.
+"""
+import json
+import pytest
+import requests
+
+# Mark all tests in this module as unit tests and music tests
+pytestmark = [pytest.mark.unit, pytest.mark.music]
+from unittest.mock import patch, MagicMock
+from src.api.music_api import (
+    get_music_api_provider,
+    CustomServerMusicAPIProvider,
+    MusicResponseOutput,
+    BaseMusicAPIProvider
+)
+
+# Sample model configuration for testing
+SAMPLE_MODEL_CONFIG = {
+    "noise": {
+        "provider": "custom-server",
+        "model_name": "noise",
+        "config": {
+            "base_url": "http://example.com/noise",
+            "check_interval": 1.0,
+            "max_wait_time": 5.0
+        }
+    },
+    "audioldm2": {
+        "provider": "custom-server",
+        "model_name": "audioldm2",
+        "config": {
+            "base_url": "http://example.com/audioldm2",
+            "check_interval": 1.0,
+            "max_wait_time": 60.0
+        }
+    }
+}
+
+class TestMusicAPI:
+    """Test the music API directly."""
+    
+    def test_base_music_api_provider(self):
+        """Test the BaseMusicAPIProvider class."""
+        # BaseMusicAPIProvider is an abstract class, so we need to create a concrete subclass
+        class TestProvider(BaseMusicAPIProvider):
+            def validate_config(self):
+                pass
+        
+        # Create an instance
+        provider = TestProvider("test-model", param1="value1", param2="value2")
+        
+        # Verify the instance
+        assert provider.model_name == "test-model"
+        assert provider.config == {"param1": "value1", "param2": "value2"}
+    
+    def test_custom_server_music_api_provider_validate_config(self):
+        """Test that the CustomServerMusicAPIProvider validates its configuration correctly."""
+        # Valid configuration
+        valid_config = {
+            "base_url": "http://example.com",
+            "check_interval": 1.0,
+            "max_wait_time": 60.0
+        }
+        provider = CustomServerMusicAPIProvider("test-model", **valid_config)
+        assert provider.model_name == "test-model"
+        assert provider.config == valid_config
+        
+        # Invalid configuration - missing required key
+        invalid_config = {
+            "base_url": "http://example.com",
+            "check_interval": 1.0
+            # Missing max_wait_time
+        }
+        with pytest.raises(ValueError, match="Missing required config key: max_wait_time"):
+            CustomServerMusicAPIProvider("test-model", **invalid_config)
+    
+    @patch("os.path.exists")
+    @patch("builtins.open")
+    def test_get_music_api_provider_with_config_file(self, mock_open, mock_exists):
+        """Test that get_music_api_provider loads configuration from a file."""
+        # Mock the file operations
+        mock_exists.return_value = True
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = json.dumps(SAMPLE_MODEL_CONFIG)
+        mock_open.return_value = mock_file
+        
+        # Test with existing model key
+        provider = get_music_api_provider("noise")
+        assert provider.model_name == "noise"
+        assert provider.config["base_url"] == "http://example.com/noise"
+        assert provider.config["check_interval"] == 1.0
+        assert provider.config["max_wait_time"] == 5.0
+        
+        # Test with non-existent model key
+        provider = get_music_api_provider("non-existent-model")
+        assert provider.model_name == "non-existent-model"
+        assert provider.config["base_url"] == "http://localhost:5000"  # Default value
+        
+        # Test with kwargs overriding config
+        provider = get_music_api_provider("noise", base_url="http://override.example.com")
+        assert provider.config["base_url"] == "http://override.example.com"
+    
+    @patch("os.path.exists")
+    def test_get_music_api_provider_without_config_file(self, mock_exists):
+        """Test that get_music_api_provider uses default configuration when no file exists."""
+        mock_exists.return_value = False
+        
+        provider = get_music_api_provider("test-model")
+        assert provider.model_name == "test-model"
+        assert provider.config["base_url"] == "http://localhost:5000"
+        assert provider.config["check_interval"] == 1.0
+        assert provider.config["max_wait_time"] == 60.0
+    
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_generate_music_success(self, mock_get, mock_post):
+        """Test successful music generation."""
+        # Mock the API responses
+        mock_post.return_value.json.return_value = {"job_id": "test-job-id"}
+        mock_post.return_value.raise_for_status = lambda: None
+        
+        # Create proper mock responses
+        class MockStatusResponse:
+            def json(self):
+                return {"status": "COMPLETE"}
+            def raise_for_status(self):
+                pass
+        
+        class MockDownloadResponse:
+            content = b"mock_audio_data"
+            def raise_for_status(self):
+                pass
+        
+        # Set up the side effect sequence
+        mock_get.side_effect = [MockStatusResponse(), MockDownloadResponse()]
+        
+        provider = CustomServerMusicAPIProvider(
+            "test-model",
+            base_url="http://example.com",
+            check_interval=0.1,
+            max_wait_time=1.0
+        )
+        
+        response = provider.generate_music("test prompt", seed=42)
+        
+        assert isinstance(response, MusicResponseOutput)
+        assert response.audio_data == b"mock_audio_data"
+        assert response.error is None
+        
+        # Verify API calls
+        mock_post.assert_called_once_with("http://example.com/submit", data={"prompt": "test prompt", "seed": 42})
+        assert mock_get.call_count == 2
+    
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_generate_music_error(self, mock_get, mock_post):
+        """Test music generation with error."""
+        # Mock the API responses
+        mock_post.return_value.json.return_value = {"job_id": "test-job-id"}
+        mock_post.return_value.raise_for_status = lambda: None
+        
+        # Create proper mock response
+        class MockErrorResponse:
+            def json(self):
+                return {"status": "ERROR"}
+            def raise_for_status(self):
+                pass
+        
+        mock_get.return_value = MockErrorResponse()
+        
+        provider = CustomServerMusicAPIProvider(
+            "test-model",
+            base_url="http://example.com",
+            check_interval=0.1,
+            max_wait_time=1.0
+        )
+        
+        response = provider.generate_music("test prompt")
+        
+        assert isinstance(response, MusicResponseOutput)
+        assert response.audio_data is None
+        assert "failed during processing" in response.error
+        
+        # Verify API calls
+        mock_post.assert_called_once_with("http://example.com/submit", data={"prompt": "test prompt"})
+        mock_get.assert_called_once()
+    
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_generate_music_timeout(self, mock_get, mock_post):
+        """Test music generation with timeout."""
+        # Mock the API responses
+        mock_post.return_value.json.return_value = {"job_id": "test-job-id"}
+        mock_post.return_value.raise_for_status = lambda: None
+        
+        # Create proper mock response
+        class MockProcessingResponse:
+            def json(self):
+                return {"status": "PROCESSING"}
+            def raise_for_status(self):
+                pass
+        
+        mock_get.return_value = MockProcessingResponse()
+        
+        provider = CustomServerMusicAPIProvider(
+            "test-model",
+            base_url="http://example.com",
+            check_interval=0.1,
+            max_wait_time=0.2  # Very short timeout for testing
+        )
+        
+        response = provider.generate_music("test prompt")
+        
+        assert isinstance(response, MusicResponseOutput)
+        assert response.audio_data is None
+        assert "timed out" in response.error
+        
+        # Verify API calls
+        mock_post.assert_called_once_with("http://example.com/submit", data={"prompt": "test prompt"})
+        assert mock_get.call_count > 1  # Should be called multiple times during polling
+    
+    @patch("requests.post")
+    def test_generate_music_request_exception(self, mock_post):
+        """Test music generation with request exception."""
+        # Mock the API response to raise an exception
+        mock_post.side_effect = requests.exceptions.RequestException("Connection error")
+        
+        provider = CustomServerMusicAPIProvider(
+            "test-model",
+            base_url="http://example.com",
+            check_interval=0.1,
+            max_wait_time=1.0
+        )
+        
+        response = provider.generate_music("test prompt")
+        
+        assert isinstance(response, MusicResponseOutput)
+        assert response.audio_data is None
+        assert "API request failed" in response.error
+        assert "Connection error" in response.error


### PR DESCRIPTION
This PR adds direct tests for the music API without relying on Starlette/FastAPI:

1. Added `test_music_api_direct.py` with unit tests that directly test the music API functionality
2. Added `test_music_api_integration.py` with integration tests for the music API
3. Both test files use proper pytest markers for categorization

These changes make the tests more focused and easier to understand, as they test the music API directly without the unnecessary complexity of the web framework.